### PR TITLE
Fix unmounted component bug

### DIFF
--- a/client/src/components/visualizations/transcript/Script.js
+++ b/client/src/components/visualizations/transcript/Script.js
@@ -15,6 +15,11 @@ export default class Script extends Component {
         this.handleScroll();
     }
 
+    // nope
+    // componentDidUpdate() {
+    //     this.handleScroll();
+    // }
+
     componentWillUnmount() {
         window.removeEventListener('scroll', this.handleScroll.bind(this));
     }

--- a/client/src/components/visualizations/transcript/Transcript.js
+++ b/client/src/components/visualizations/transcript/Transcript.js
@@ -16,6 +16,7 @@ export default class Transcript extends Component {
         // double width - for both left/right side of TurnTakingSmall chart
         this.chartWidth = 2 * Parser.maxNTokens();
 
+        console.log("constructor");
         this.state = {
             activeLabels: [],
             focusBox: {
@@ -39,6 +40,7 @@ export default class Transcript extends Component {
             buttonSelector = buttonSelectorDiv && buttonSelectorDiv[0],
             chartHeight = window.innerHeight - 2.5 * (navbar.clientHeight - buttonSelector.clientHeight); // this is good enough for now; ideally it captures focusBox.height in its sizing of the chart
 
+        console.log("Transcript::componentDidMount");
         this.setState({
             chartOffsetWidth: chartOffsetWidth,
             chartHeight: chartHeight
@@ -55,6 +57,7 @@ export default class Transcript extends Component {
             activeLabels.push(label.value);
         }
 
+        console.log("Transcript::handleClick");
         this.setState({
             activeLabels: activeLabels
         });
@@ -77,6 +80,8 @@ export default class Transcript extends Component {
         // focus the box
         turnTakingBarsSmall.scrollTo(0, topElId * this.barHeight);
 
+        console.log("Transcript::handleScroll");
+        console.log("this", this);
         this.setState({
             focusBox: {
                 topElId: topElId,

--- a/client/src/components/visualizations/transcript/Turn.js
+++ b/client/src/components/visualizations/transcript/Turn.js
@@ -8,9 +8,10 @@ export default class HoverScript extends Component {
 
     render() {
         var turn = this.props.data;
+        var utteranceId = `utterance${turn.id}`
 
         return (
-          <div className="script-turn-container" id={turn.id} onClick={this.handleTextClick.bind(this, turn.id)}>
+          <div className="script-turn-container" id={utteranceId} onClick={this.handleTextClick.bind(this, utteranceId)}>
             <table className="script-turn">
               <tbody className="script-turn-rows">
                 <tr className="script-turn-speaker">

--- a/client/src/components/visualizations/transcript/Utterance.js
+++ b/client/src/components/visualizations/transcript/Utterance.js
@@ -23,8 +23,10 @@ export default class Utterance extends Component {
             }
         }
 
+        var utteranceId = `utterance${utterance.id}`;
+
         return (
-          <tr className="script-turn-utterance" data-attr-utterance-id={utterance.id} id={utterance.id} onClick={this.handleUtteranceClick.bind(this, utterance.id)}>
+          <tr className="script-turn-utterance" data-attr-utterance-id={utterance.id} id={utteranceId} onClick={this.handleUtteranceClick.bind(this, utteranceId)}>
             <td className="script-turn-utterance-timestamp">
               {timeStamp}
             </td>

--- a/client/src/components/visualizations/turn-taking/TurnTaking.js
+++ b/client/src/components/visualizations/turn-taking/TurnTaking.js
@@ -47,6 +47,7 @@ export default class TurnTaking extends Component {
     }
 
     toggleExpandedBars = function(value, context) {
+        console.log("TurnTaking::toggleExpandedBars");
         this.setState({ "bars": value });
         localStorage.setItem("bars", value);
     }
@@ -72,6 +73,7 @@ export default class TurnTaking extends Component {
             activeFilters.push(label.value);
         }
 
+        console.log("TurnTaking::handleFilterClick");
         this.setState({
             activeFilters: activeFilters
         });
@@ -82,6 +84,7 @@ export default class TurnTaking extends Component {
             value = {};
         }
 
+        console.log("TurnTaking::handleBarClick");
         this.setState({
             activeTurn: value
         });


### PR DESCRIPTION
Go to TalkRatio or TurnTaking visualization, click into a set of utterances and drilldown to the Transcript visualization. The following error appears:

Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.
To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

References
- https://reactjs.org/docs/hooks-overview.html
- https://www.freecodecamp.org/news/how-to-work-with-react-the-right-way-to-avoid-some-common-pitfalls-fc9eb5e34d9e/
